### PR TITLE
removed default phpcs standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let g:phpqa_messdetector_ruleset = "/path/to/phpmd.xml"
 For PHP code sniffer, you can pass arguments to the command line binary (run `phpcs --help` to see a list). For example:
 
 ```vim
-" Set the codesniffer args (default = "--standard=PHPCS")
+" Set the codesniffer args
 let g:phpqa_codesniffer_args = "--standard=Zend"
 ```
 

--- a/plugin/phpqa.vim
+++ b/plugin/phpqa.vim
@@ -43,7 +43,7 @@ endif
 
 " Arguments to pass to code sniffer, e.g standard name
 if !exists("g:phpqa_codesniffer_args")
-    let g:phpqa_codesniffer_args="--standard=PHPCS"
+    let g:phpqa_codesniffer_args=""
 endif
 
 " PHPMD binary (mess detector)


### PR DESCRIPTION
The default phpcs standard of `--standard=PHPCS` doesn't make sense to me. I can set the global standard with 

```
phpcs --config-set default_standard PSR2
```

but phpqa's default _overrides_ my default standard. So I _have_ to re-specify my default standard again in .vimrc. Why not just default to the phpcs default standard and let people add a specific standard if they like?
