### PR TITLE
fix PhpqaPhp#CodeCoverage undefined function error.

### DIFF
--- a/plugin/Phpqa.vim
+++ b/plugin/Phpqa.vim
@@ -115,7 +115,7 @@ endf
 function! PhpqaRunCodeCoverage()
     if &filetype == 'php'
         if "" != g:phpqa_codecoverage_file && 1 == g:phpqa_codecoverage_autorun
-            call PhpqaPhp#CodeCoverage()
+            call Phpqa#PhpCodeCoverage()
         endif
     endif
 endf


### PR DESCRIPTION
Fix this error when is g:phpqa_codecoverage_autorun is enabled:

Error detected while processing function PhpqaRunCodeCoverage:  
line    3:  
E117: Unknown function: PhpqaPhp#CodeCoverage
