### PR TITLE
Fix a error when clover.xml file does not exists.

### DIFF
--- a/autoload/Phpqa.vim
+++ b/autoload/Phpqa.vim
@@ -227,7 +227,9 @@ function! Phpqa#PhpCodeCoverage()
             echohl Error |echo "Not a valid or readable file"|echohl None
         endif
     endwhile
-    call AddCodeCoverageSigns(g:phpqa_codecoverage_file)
+    if filereadable(g:phpqa_codecoverage_file)
+        call AddCodeCoverageSigns(g:phpqa_codecoverage_file)
+    endif
 endf
 " }}}1
 "=============================================================================


### PR DESCRIPTION
Fixes the following error when g:phpqa_codecoverage_autorun is enabled and g:phpqa_codecoverage_file does not exists. 

```
"index.php" 188L, 5391CI/O warning : failed to load external entity "build/logs/clover.xml"

An error has occured while parsing the code coverage file
```
