### PR TITLE
general: disable plugin if php not available.

### DIFF
--- a/plugin/Phpqa.vim
+++ b/plugin/Phpqa.vim
@@ -14,6 +14,11 @@
 " }}}
 "-------------------------------------------------
 
+" Disable plugin if php isn't available
+if 0 == has("php")
+    finish
+endif
+
 if exists("g:phpqa_check")
     finish
 endif


### PR DESCRIPTION
* Adds a check if php exists. If not exists, autodisable.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>