### PR TITLE
Add support for PHPCBF

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin for Vim that integrates PHP quality checking tools, to allow you to code to a particular standard and easily spot errors and violations.
 
-It uses PHP linter to check for syntax errors, and integrates with [PHP Code Sniffer][1] and [PHP Mess Detector][2] to check for coding standard violations, and shows code coverage from clover XML files.
+It uses PHP linter to check for syntax errors, and integrates with [PHP Code Sniffer][1] and [PHP Mess Detector][2] to check for coding standard violations, and shows code coverage from clover XML files. It also integrates with [PHPCBF][7] to automatically fix some code standards violations.
 
 ### Quick Guide
 
@@ -15,6 +15,7 @@ You can toggle markers with the following commands (in command mode):
 ```vim
 <Leader>qa	" Show/hide code sniffer and mess detector violations
 <Leader>qc	" Show/hide code coverage markers
+<Leader>qf	" Run PHPCBF to fix some of the sniffer violations
 ```
 
 What's the `<Leader>` key? It's likely to be either `\` or `,`, but you can set it from the command line or in your *.vimrc* file using:
@@ -31,6 +32,7 @@ You can also run each command separately on demand:
 - `:Phpcs` - run code sniffer
 - `:Phpmd` - run mess detector (will ask for a rule XML file if not set) 
 - `:Phpcc` - show code coverage (will ask for a clover XML file if not set)
+- `:Phpcbs` - run phpcbf to reformat your code up to your configured standards (same as phpcs). It saves the file before running it.
 
 ### Code Coverage
 
@@ -101,6 +103,9 @@ let g:phpqa_codesniffer_autorun = 0
 
 " Show code coverage on load (default = 0)
 let g:phpqa_codecoverage_autorun = 1
+
+" Run PHPCBF on save (default = 0)
+let g:phpqa_codefixer_autorun = 1
 ```
 
 By default, the location list window will open when mess detector/codesniffer violations are found. You can stop this happening by setting this option:
@@ -136,3 +141,4 @@ This plugin is released under the [MIT License][6].
 [4]: https://github.com/gmarik/vundle
 [5]: http://www.vim.org/scripts/script.php?script_id=124
 [6]: https://github.com/joonty/vim-phpqa/raw/master/LICENSE
+[7]: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically

--- a/autoload/Phpqa.vim
+++ b/autoload/Phpqa.vim
@@ -135,6 +135,24 @@ function! Phpqa#PhpCodeSniffer()
     return l:phpcs_list
 endf
 
+" Run PHP code fixer.
+function! Phpqa#PhpCodeFixer()
+    if @% == ""
+        echohl Error | echo "Invalid buffer (are you in the error window?)" |echohl None
+        return []
+    endif
+    " Run codefixer if the command hasn't been unset
+	if 0 != len(g:phpqa_codefixer_cmd)
+        write
+		call system(g:phpqa_codefixer_cmd." ".g:phpqa_codesniffer_args." ".@%)
+		edit
+	else
+        if 1 == g:phpqa_verbose
+            echohl Error | echo "PHPCBF binary set to empty, not running code beautifier and fixer" | echohl None
+        endif
+    endif
+endf
+
 " Run mess detector.
 "
 " The user is required to specify a ruleset XML file if they haven't already.
@@ -160,7 +178,7 @@ function! Phpqa#PhpMessDetector()
 endf
 
 " Run Code Sniffer and Mess Detector.
-function! Phpqa#PhpQaTools(runcs,runmd)
+function! Phpqa#PhpQaTools(runcs,runmd,runcbf)
     let l:bufNo = bufnr('%')
     call s:RemoveSigns()
 
@@ -174,6 +192,10 @@ function! Phpqa#PhpQaTools(runcs,runmd)
         let l:phpmd_list = Phpqa#PhpMessDetector()
     else
         let l:phpmd_list = []
+    endif
+
+	if 1 == a:runcbf
+		call Phpqa#PhpCodeFixer()
     endif
 
     let error_list=s:CombineLists(l:phpcs_list,l:phpmd_list)

--- a/plugin/Phpqa.vim
+++ b/plugin/Phpqa.vim
@@ -46,6 +46,12 @@ if !exists("g:phpqa_codesniffer_cmd")
     let g:phpqa_codesniffer_cmd='phpcs'
 endif
 
+" PHPCBF binary (PHP_CodeSniffer)
+if !exists("g:phpqa_codefixer_cmd")
+    let g:phpqa_codefixer_cmd='phpcbf'
+endif
+
+
 " Arguments to pass to code sniffer, e.g standard name
 if !exists("g:phpqa_codesniffer_args")
     let g:phpqa_codesniffer_args=""
@@ -88,6 +94,11 @@ if !exists("g:phpqa_codesniffer_autorun")
     let g:phpqa_codesniffer_autorun = 1
 endif
 
+" Whether to automatically run codefixer when saving a file
+if !exists("g:phpqa_codefixer_autorun")
+    let g:phpqa_codefixer_autorun = 0
+endif
+
 " Whether to automatically run messdetector when saving a file
 if !exists("g:phpqa_messdetector_autorun")
     let g:phpqa_messdetector_autorun = 1
@@ -111,7 +122,7 @@ function! PhpqaRunAll()
         " Check syntax valid before running others
         let retval=Phpqa#PhpLint()
         if 0 == retval && 1 == g:phpqa_run_on_write
-            call Phpqa#PhpQaTools(g:phpqa_codesniffer_autorun,g:phpqa_messdetector_autorun)
+            call Phpqa#PhpQaTools(g:phpqa_codesniffer_autorun,g:phpqa_messdetector_autorun,g:phpqa_codefixer_autorun)
         endif
     endif
 endf
@@ -140,8 +151,9 @@ endif
 
 " Allow each command to be called individually
 command Php call Phpqa#PhpLint()
-command Phpcs call Phpqa#PhpQaTools(1,0)
-command Phpmd call Phpqa#PhpQaTools(0,1)
+command Phpcs call Phpqa#PhpQaTools(1,0,0)
+command Phpcbf call Phpqa#PhpQaTools(0,0,1)
+command Phpmd call Phpqa#PhpQaTools(0,1,0)
 command Phpcc call Phpqa#PhpCodeCoverage()
 
 

--- a/plugin/Phpqa.vim
+++ b/plugin/Phpqa.vim
@@ -163,6 +163,12 @@ endif
 nnoremap <unique> <script> <Plug>QAToolsToggle <SID>QAToolsToggle
 nnoremap <silent> <SID>QAToolsToggle :call Phpqa#QAToolsToggle()<cr>
 
+if !hasmapto('<Plug>PhpCodeFixer', 'n')
+    nmap <unique> <Leader>qf  <Plug>PhpCodeFixer
+endif
+nnoremap <unique> <script> <Plug>PhpCodeFixer <SID>PhpCodeFixer
+nnoremap <silent> <SID>PhpCodeFixer :call Phpqa#PhpCodeFixer()<cr>
+
 " Code sniffer sign config
 let g:phpqa_codesniffer_append = "(PHP_CodeSniffer)"
 let g:phpqa_codesniffer_type = "S"


### PR DESCRIPTION
PHP Codesniffer ships with `phpcbf`, a command that can automatically fix a lot of the issues that `phpcs` founds. This PR adds support for `phpcb` inside vim.
